### PR TITLE
Refactor batch processing

### DIFF
--- a/examples/lstm_usage.ipynb
+++ b/examples/lstm_usage.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, agent, hidden_states = jax_ppo.init_lstm_agent(\n",
+    "_, agent = jax_ppo.init_lstm_agent(\n",
     "    k, \n",
     "    params,\n",
     "    env.action_space().shape,\n",

--- a/jax_ppo/mlp/agent.py
+++ b/jax_ppo/mlp/agent.py
@@ -16,7 +16,6 @@ def init_agent(
     action_space_shape: typing.Tuple[int, ...],
     observation_space_shape: typing.Tuple[int, ...],
     schedule: typing.Union[float, optax._src.base.Schedule],
-    n_agents: int = 1,
     layer_width: int = 64,
     n_layers: int = 2,
     activation: flax.linen.activation = flax.linen.tanh,
@@ -36,7 +35,7 @@ def init_agent(
         ),
     )
 
-    fake_args_model = jnp.zeros((n_agents,) + observation_space_shape)
+    fake_args_model = jnp.zeros(observation_space_shape)
 
     key, sub_key = jax.random.split(key)
     params_model = policy.init(sub_key, fake_args_model)

--- a/jax_ppo/mlp/algos.py
+++ b/jax_ppo/mlp/algos.py
@@ -11,7 +11,7 @@ from jax_ppo.mlp.data_types import Batch, Trajectory
 
 @partial(jax.jit, static_argnames="apply_fn")
 def policy(apply_fn, params, state):
-    mean, log_std, value = apply_fn(params, state)
+    mean, log_std, value = jax.vmap(apply_fn, in_axes=(None, 0))(params, state)
     return mean, log_std, value
 
 
@@ -20,7 +20,7 @@ def sample_actions(key: jax.random.PRNGKey, agent: Agent, state):
     key, sub_key = jax.random.split(key)
     dist = distrax.MultivariateNormalDiag(mean, jnp.exp(log_std))
     actions, log_likelihood = dist.sample_and_log_prob(seed=sub_key)
-    return key, actions, log_likelihood, value[:, 0]
+    return key, actions, log_likelihood, value
 
 
 def max_action(agent: Agent, state):

--- a/jax_ppo/mlp/policy.py
+++ b/jax_ppo/mlp/policy.py
@@ -18,8 +18,7 @@ class ActorCritic(linen.module.Module):
     @linen.compact
     def __call__(self, x):
 
-        value = x
-        mean = x
+        value, mean = x, x
 
         for _ in range(self.n_layers):
             value = linen.Dense(self.layer_width, **layer_init())(value)
@@ -35,4 +34,4 @@ class ActorCritic(linen.module.Module):
             "log_std", linen.initializers.zeros, (self.single_action_shape,)
         )
 
-        return mean, log_std, value
+        return mean, log_std, value[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def mlp_agent(key):
         (N_ACTIONS,),
         (N_OBS,),
         0.01,
-        n_agents=1,
         layer_width=8,
         n_layers=1,
     )
@@ -34,18 +33,17 @@ def mlp_agent(key):
 
 @pytest.fixture
 def recurrent_agent(key):
-    _, agent, hidden_states = jax_ppo.init_lstm_agent(
+    _, agent = jax_ppo.init_lstm_agent(
         key,
         jax_ppo.default_params,
         (N_ACTIONS,),
         (N_OBS,),
         0.01,
         SEQ_LEN,
-        n_agents=N_AGENTS,
         layer_width=8,
         n_layers=1,
     )
-    return agent, hidden_states
+    return agent
 
 
 @pytest.fixture

--- a/tests/mlp/test_policy.py
+++ b/tests/mlp/test_policy.py
@@ -12,10 +12,10 @@ def observation():
 
 
 def test_policy_output_shapes(mlp_agent, observation):
-    mean, log_std, value = mlp_agent.apply_fn(mlp_agent.params, observation)
-    assert mean.shape == (N_AGENTS, N_ACTIONS)
+    mean, log_std, value = mlp_agent.apply_fn(mlp_agent.params, observation[0])
+    assert mean.shape == (N_ACTIONS,)
     assert log_std.shape == (N_ACTIONS,)
-    assert value.shape == (N_AGENTS, 1)
+    assert value.shape == ()
 
 
 def test_policy_sampling_shape(key, mlp_agent, observation):

--- a/tests/recurrent/test_sampling.py
+++ b/tests/recurrent/test_sampling.py
@@ -9,11 +9,10 @@ N_SAMPLES = 11
 
 
 def test_policy_sampling(key, recurrent_agent, dummy_env):
-    agent, _ = recurrent_agent
     trajectories = training.generate_samples(
         env=dummy_env,
         env_params=dummy_env.default_params,
-        agent=agent,
+        agent=recurrent_agent,
         n_samples=N_SAMPLES,
         n_agents=None,
         key=key,
@@ -33,11 +32,10 @@ def test_policy_sampling(key, recurrent_agent, dummy_env):
 
 
 def test_marl_policy_sampling(key, recurrent_agent, dummy_marl_env):
-    agent, _ = recurrent_agent
     trajectories = training.generate_samples(
         env=dummy_marl_env,
         env_params=dummy_marl_env.default_params,
-        agent=agent,
+        agent=recurrent_agent,
         n_samples=N_SAMPLES,
         n_agents=N_AGENTS,
         key=key,
@@ -57,12 +55,11 @@ def test_marl_policy_sampling(key, recurrent_agent, dummy_marl_env):
 
 
 def test_policy_testing(key, recurrent_agent, dummy_env):
-    agent, _ = recurrent_agent
     burn_in = 3
     state_ts, reward_ts, _ = training.test_policy(
         env=dummy_env,
         env_params=dummy_env.default_params,
-        agent=agent,
+        agent=recurrent_agent,
         n_steps=N_SAMPLES,
         n_agents=None,
         key=key,
@@ -80,12 +77,11 @@ def test_policy_testing(key, recurrent_agent, dummy_env):
 
 
 def test_marl_policy_testing(key, recurrent_agent, dummy_marl_env):
-    agent, _ = recurrent_agent
     burn_in = 3
     state_ts, reward_ts, _ = training.test_policy(
         env=dummy_marl_env,
         env_params=dummy_marl_env.default_params,
-        agent=agent,
+        agent=recurrent_agent,
         n_steps=N_SAMPLES,
         n_agents=N_AGENTS,
         key=key,


### PR DESCRIPTION
Use `jax.vmap` to apply policies across batches (rather than working with batches directly)